### PR TITLE
Implement switch for ph.d dissertation vs. masters thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Contents
 
 This folder should contain:
 
-* **template.tex**             Primary Driver File
-* **template_frontmatter.tex** Where the title, abstract, etc. are held.
+* **template.tex**             Primary Driver File (edit!)
+* **template_frontmatter.tex** Where the title, abstract, etc. are held (edit!).
+* **languages/en.tex**         Strings used in the document (do not edit). 
 * **ucsd.cls**                 LaTeX class file
-* **uct10.clo**                Font files associated to LaTeX class file
-* **uct11.clo**
-* **uct12.clo**
+* **uct12.clo**                Font files associated to LaTeX class file
 
 Instructions
 ------------
@@ -31,6 +30,10 @@ A common alternate strategy is to include a files for each of the chapters
 \include{chapter1}
 ```
 
+For masters degree: change 'phd' to 'masters' in `template.tex:105`
+* All template changes should be automatic.
+
+
 For more information go to the [project wiki page][1].
 
 [1]: http://code.google.com/p/ucsd-thesis/wiki/GettingStarted
@@ -42,7 +45,7 @@ This template has not endorced by OGS or any other official entity.
 The official formatting guide can be obtained from
 [OGS](http://ogs.ucsd.edu/AcademicAffairs/Documents/Dissertations_Theses_Formatting_Manual.pdf).
 
-No guaranty is made that this LaTeX class conforms to the official UCSD guidelines.
+No guarantee is made that this LaTeX class conforms to the official UCSD guidelines.
 Make sure that you check the final document against the Formatting Manual.
 
 That being said, this class has been routinely used for successful

--- a/languages/en.tex
+++ b/languages/en.tex
@@ -14,13 +14,12 @@
 % \tableofcontents:
 
  \ifnum\pdfstrcmp{\@degree}{masters}=0 %
-     \def\titleddoctype{Thesis}
+     \def\doctype{Thesis}
      \def\thedegree{Master of Science}
 \else
-     \def\titleddoctype{Dissertation}
+     \def\doctype{Dissertation}
      \def\thedegree{Doctor of Philosophy}
 \fi
-\def\doctype{\MakeLowercase{\titleddoctype}}
 
 \def\contentsshortname{Contents}
 \def\contentslongname{Table of Contents}
@@ -61,8 +60,8 @@
 \def\partname{Part}
 %             ~~~~
 % abstract environment:
-\def\abstractshortname{Abstract of the {\titleddoctype}} % Used for TOC
-\def\abstractlongname{Abstract of the {\titleddoctype}} % Used for Header
+\def\abstractshortname{Abstract of the {\doctype}} % Used for TOC
+\def\abstractlongname{Abstract of the {\doctype}} % Used for Header
 %                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 % dedication:
 \def\dedicationname{Dedication}

--- a/languages/en.tex
+++ b/languages/en.tex
@@ -12,6 +12,16 @@
 % supporting the title and approval pages.
 %
 % \tableofcontents:
+
+ \ifnum\pdfstrcmp{\@degree}{masters}=0 %
+     \def\titleddoctype{Thesis}
+     \def\thedegree{Masters of Science}
+\else
+     \def\titleddoctype{Dissertation}
+     \def\thedegree{Doctor of Philosophy}
+\fi
+\def\doctype{\MakeLowercase{\titleddoctype}}
+
 \def\contentsshortname{Contents}
 \def\contentslongname{Table of Contents}
 %                 ~~~~~~~~~~~~~~~~~
@@ -51,8 +61,8 @@
 \def\partname{Part}
 %             ~~~~
 % abstract environment:
-\def\abstractshortname{Abstract of the Dissertation} % Used for TOC
-\def\abstractlongname{Abstract of the Dissertation} % Used for Header
+\def\abstractshortname{Abstract of the {\doctype}} % Used for TOC
+\def\abstractlongname{Abstract of the {\doctype}} % Used for Header
 %                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 % dedication:
 \def\dedicationname{Dedication}
@@ -94,7 +104,7 @@
 % Since OGS has very specific requirements for line breaks, they've
 % been broken into different variables for translation.
 % Non-english languages will have to compensate as-is....
-\def\Dissertationpreambename{A dissertation submitted in partial satisfaction of the}
+\def\Dissertationpreambename{A {\doctype} submitted in partial satisfaction of the}
 \def\Requirementspreamblename{requirements for the degree}
 \def\Degreeinpreamblename{in}  % used as "[degree title] in [degree field]"
 

--- a/languages/en.tex
+++ b/languages/en.tex
@@ -15,7 +15,7 @@
 
  \ifnum\pdfstrcmp{\@degree}{masters}=0 %
      \def\titleddoctype{Thesis}
-     \def\thedegree{Masters of Science}
+     \def\thedegree{Master of Science}
 \else
      \def\titleddoctype{Dissertation}
      \def\thedegree{Doctor of Philosophy}
@@ -61,8 +61,8 @@
 \def\partname{Part}
 %             ~~~~
 % abstract environment:
-\def\abstractshortname{Abstract of the {\doctype}} % Used for TOC
-\def\abstractlongname{Abstract of the {\doctype}} % Used for Header
+\def\abstractshortname{Abstract of the {\titleddoctype}} % Used for TOC
+\def\abstractlongname{Abstract of the {\titleddoctype}} % Used for Header
 %                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 % dedication:
 \def\dedicationname{Dedication}

--- a/template.tex
+++ b/template.tex
@@ -1,6 +1,6 @@
 %
 %
-% UCSD Doctoral Dissertation Template
+% UCSD Doctoral Dissertation and Masters Thesis Template
 % -----------------------------------
 % https://github.com/ucsd-thesis/ucsd-thesis
 %
@@ -19,8 +19,8 @@
 %   That being said, this class has been routinely used for successful 
 %   publication of doctoral theses.  
 %
-%   The ucsd.cls class files are only valid for doctoral dissertations.
-%
+%   The ucsd.cls class files are valid for doctoral dissertations and
+%    masters theses.
 %
 % ----------------------------------------------------------------------
 % GETTING STARTED:
@@ -77,7 +77,7 @@
 % Setup the documentclass 
 % default options: 12pt, oneside, final
 %
-% fonts: 10pt, 11pt, 12pt -- are valid for UCSD dissertations.
+% fonts: 10pt, 11pt, 12pt -- are valid for UCSD dissertations and theses.
 % sides: oneside, twoside -- note that two-sided theses are not accepted 
 %                            by OGS.
 % mode: draft, final, lulu -- 
@@ -89,6 +89,9 @@
 %                            lulu mode prints to 6x9, single spacing, and ready for 
 %                            double-sided printing.
 %
+% degree: phd, masters --
+%                            this changes the template to conform to (dissertation or thesis needs)
+%
 % chapterheads            -- Include this if you want your chapters to read:
 %                              Chapter 1
 %                              Title of Chapter
@@ -99,7 +102,7 @@
 % en                      (default) you can add translations to languages/[lang].tex,
 %                           then switch languages.
 %
-\documentclass[12pt,final,chapterheads]{ucsd}
+\documentclass[12pt,final,phd,chapterheads]{ucsd}  % or masters instead of phd
 
 
 % Include all packages you need here.  
@@ -113,7 +116,7 @@
 
 
 %% AMS PACKAGES - Chances are you will want some or all 
-%    of these if writing a dissertation that includes equations.
+%    of these if writing a dissertation/thesis that includes equations.
 %  \usepackage{amsmath, amscd, amssymb, amsthm}
 
 %% GRAPHICX - This is the standard package for 
@@ -159,7 +162,7 @@
 %             urlcolor=black, plainpages=false,
 %             pdfpagelabels]{hyperref}
 % \hypersetup{ pdfauthor = {Your Name Here}, 
-%              pdftitle = {The Title of The Dissertation}, 
+%              pdftitle = {The Title of The \doctype}, 
 %              pdfkeywords = {Keywords for Searching}, 
 %              pdfcreator = {pdfLaTeX with hyperref package}, 
 %              pdfproducer = {pdfLaTeX} }
@@ -172,6 +175,8 @@
 % and fixes up citations madness
 \usepackage{microtype}  % avoids citations that hang into the margin
 
+%% String comparisons
+\usepackage{pdftexcmds}
 
 %% FOOTNOTE-MAGIC
 % Enables footnotes in tables, re-referencing the same footnote multiple times.

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -11,7 +11,7 @@
 
 % No symbols, formulas, superscripts, or Greek letters are allowed
 % in your title.
-\title{The Title Of The Dissertation}
+\title{The Title Of The {\titleddoctype}}
 
 \author{Your Name Here}
 \degreeyear{\the\year}
@@ -19,7 +19,7 @@
 
 
 % Master's Degree theses will NOT be formatted properly with this file.
-\degreetitle{Doctor of Philosophy}
+\degreetitle{\thedegree}
 
 \field{Mathematics}
 \specialization{Anthropogeny}  % If you have a specialization, add it here
@@ -153,11 +153,11 @@ Professor Cirius Thinker\\
 
 %% ABSTRACT
 %
-%  Doctoral dissertation abstracts should not exceed 350 words.
+%  Doctoral dissertation / thesis abstracts should not exceed 350 words.
 %   The abstract may continue to a second page if necessary.
 %
 \begin{abstract}
-  This dissertation will be abstract.
+  This \doctype will be abstract.
 \end{abstract}
 
 

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -22,7 +22,7 @@
 \degreetitle{\thedegree}
 
 \field{Mathematics}
-\specialization{Anthropogeny}  % If you have a specialization, add it here
+% \specialization{Anthropogeny}  % If you have a specialization, add it here
 
 \chair{Professor Chair Master}
 % Uncomment the next line iff you have a Co-Chair

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -37,8 +37,11 @@ Professor Humor Less\\
 Professor Ironic Name\\
 Professor Cirius Thinker\\
 }
-\numberofmembers{4} % |chair| + |cochair| + |othermembers|
-
+ \ifnum\pdfstrcmp{\@degree}{masters}=0 %
+    \numberofmembers{3} % |chair| + |cochair| + |othermembers|
+\else
+    \numberofmembers{4} % |chair| + |cochair| + |othermembers|
+\fi
 
 %% START THE FRONTMATTER
 %

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -163,7 +163,7 @@ Professor Cirius Thinker\\
 %   The abstract may continue to a second page if necessary.
 %
 \begin{abstract}
-  This \doctype will be abstract.
+  This {\doctype} will be abstract.
 \end{abstract}
 
 

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -11,7 +11,7 @@
 
 % No symbols, formulas, superscripts, or Greek letters are allowed
 % in your title.
-\title{The Title Of The {\titleddoctype}}
+\title{The Title Of The {\doctype}}
 
 \author{Your Name Here}
 \degreeyear{\the\year}
@@ -163,7 +163,7 @@ Professor Cirius Thinker\\
 %   The abstract may continue to a second page if necessary.
 %
 \begin{abstract}
-  This {\doctype} will be abstract.
+  This \MakeLowercase{\doctype} will be abstract.
 \end{abstract}
 
 

--- a/template_frontmatter.tex
+++ b/template_frontmatter.tex
@@ -138,18 +138,21 @@ Professor Cirius Thinker\\
 %  A brief vita is required in a doctoral thesis. See the OGS
 %  Formatting Manual for more information.
 %
-\begin{vitapage}
-\begin{vita}
-  \item[2002] B.~S. in Mathematics \emph{cum laude}, University of Southern North Dakota, Hoople
-  \item[2002-2007] Graduate Teaching Assistant, University of California, San Diego
-  \item[2007] Ph.~D. in Mathematics, University of California, San Diego
-\end{vita}
-\begin{publications}
-  \item Your Name, ``A Simple Proof Of The Riemann Hypothesis'', \emph{Annals of Math}, 314, 2007.
-  \item Your Name, Euclid, ``There Are Lots Of Prime Numbers'', \emph{Journal of Primes}, 1, 300 B.C.
-\end{publications}
-\end{vitapage}
-
+% Vita is optional for masters thesis; we exclude it here.
+%
+ \ifnum\pdfstrcmp{\@degree}{phd}=0 %
+    \begin{vitapage}
+    \begin{vita}
+      \item[2002] B.~S. in Mathematics \emph{cum laude}, University of Southern North Dakota, Hoople
+      \item[2002-2007] Graduate Teaching Assistant, University of California, San Diego
+      \item[2007] Ph.~D. in Mathematics, University of California, San Diego
+    \end{vita}
+    \begin{publications}
+      \item Your Name, ``A Simple Proof Of The Riemann Hypothesis'', \emph{Annals of Math}, 314, 2007.
+      \item Your Name, Euclid, ``There Are Lots Of Prime Numbers'', \emph{Journal of Primes}, 1, 300 B.C.
+    \end{publications}
+    \end{vitapage}
+\fi
 
 %% ABSTRACT
 %

--- a/ucsd.cls
+++ b/ucsd.cls
@@ -1,5 +1,5 @@
     %
-% UCSD Dissertation Class
+% UCSD Dissertation/Thesis Class
 %
 %   For the latest version go to:
 %     http://ucsd-thesis.googlecode.com
@@ -24,7 +24,7 @@
 %%%     docstring       = "This file is the main file for the ucsd-thesis
 %%%                        class, which is intended to meet the requirements
 %%%                        for University of California San Diego
-%%%                        Ph.D. dissertations.",
+%%%                        Ph.D. dissertations and masters theses.",
 %%%
 %%%
 %%%                    UCTHESIS.STY v2.7 is based on the standard
@@ -203,7 +203,7 @@
 %%%
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{ucsd}[2015/02/08 v4.1 University of California, San Diego, Dissertation Class]
+\ProvidesClass{ucsd}[2015/10/31 v4.2 University of California, San Diego, Dissertation/Thesis Class]
 
 
 %    ****************************************
@@ -221,11 +221,14 @@
 \DeclareOption{oneside}{\@twosidefalse \@mparswitchfalse}
 \DeclareOption{twoside}{\@twosidetrue  \@mparswitchtrue}
 
-
 \newcommand\@draftmark{}
 \DeclareOption{draft}{\renewcommand\@draftmark{1}}
 \DeclareOption{final}{\renewcommand\@draftmark{0}}
 \DeclareOption{lulu}{\renewcommand\@draftmark{-1}}
+
+\newcommand\@degree{phd}
+\DeclareOption{masters}{\renewcommand\@degree{masters}}
+\DeclareOption{phd}{\renewcommand\@degree{phd}}
 
 % Add new language options here
 \newcommand\@lang{en}
@@ -431,7 +434,7 @@
 
 \def\makefrontmatter{
 % TITLE PAGE.
-% This is the first page of the dissertation.  The format
+% This is the first page of the dissertation/thesis.  The format
 % is specified by OGS.
 %
 {\ssp
@@ -516,7 +519,7 @@ All rights reserved.}
 \begin{center}
 \vspace{.25in}
 \vspace{\@approvalspace}
-\makebox[4in][l]{\parbox{4in}{\fmfont The dissertation of {\@author}
+\makebox[4in][l]{\parbox{4in}{\fmfont The \MakeLowercase{\doctype} of {\@author}
 is approved, and it is acceptable in quality and form for publication
 on microfilm and electronically: }}\\
 \begin{tabular*}{4in}[t]{r@{\extracolsep{\fill}}r}
@@ -659,7 +662,7 @@ on microfilm and electronically: }}\\
 %
 % The ABSTRACT environment allows for multi-page abstracts which,
 % in accordance with UC rules, is numbered separately from the rest
-% of the rest of the dissertation in Arabic.  It requires definition
+% of the rest of the dissertation/thesis in Arabic.  It requires definition
 % of the \title, \author, \degreetitle, \field, \campus, and \chair macros.
 % The page numbering is in the usual sequence for UCSD OGS--WBB.
 %
@@ -713,7 +716,7 @@ on microfilm and electronically: }}\\
 % The FRONTMATTER environment makes sure that page numbering is set
 % correctly (roman, lower-case, starting at 3) for the front matter
 % that follows the abstract.  It also resets page-numbering for
-% the remainder of the dissertation (arabic, starting at 1).
+% the remainder of the dissertation/thesis (arabic, starting at 1).
 % (WBB) At UCSD: put everything, including \titlepage,\copyrightpage,
 % \approvalpage in frontmatter.
 % Changed def. WBB to go with change in use of frontmatter.

--- a/ucsd.cls
+++ b/ucsd.cls
@@ -519,7 +519,7 @@ All rights reserved.}
 \begin{center}
 \vspace{.25in}
 \vspace{\@approvalspace}
-\makebox[4in][l]{\parbox{4in}{\fmfont The \MakeLowercase{\doctype} of {\@author}
+\makebox[4in][l]{\parbox{4in}{\fmfont The {\doctype} of {\@author}
 is approved, and it is acceptable in quality and form for publication
 on microfilm and electronically: }}\\
 \begin{tabular*}{4in}[t]{r@{\extracolsep{\fill}}r}


### PR DESCRIPTION
@jlshin was kind enough to make changes to enable both in #16 . However, she separated the templates for thesis vs. dissertation code, which is harder to maintain.

@jlshin was kind enough to list the differences between the docs, and they were quite small. So, I implemented them in the same template. Just change from:
```tex
\documentclass[12pt,final,phd,chapterheads]{ucsd}  % or masters instead of phd
```
to
```tex
\documentclass[12pt,final,masters,chapterheads]{ucsd}  % or masters instead of phd
```

Differences between thesis and dissertation (from @jlshin), implemented here:

Change in ucsd.cls and both template files:
1. "dissertation" and "Dissertation" to "Thesis" (note capitalization)
2. "Doctor of Philosophy" to "Master of Science"

In front_matter:
1. Remove Vita or indicate that it's optional 
2. Default committee members + chair = 3
