### PR TITLE
short figure/table captions must be truncations

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -237,7 +237,8 @@ This subsection shows a sample figure.
 \begin{figure}[h] 
   \centering
   \includegraphics[width=0.5\textwidth]{sandiego}
-  \caption[Short figure caption (must be \protect{$< 4$} lines in the list of figures)]{A picture of San Diego.  Note that figures must be on their own line (no neighboring text) and captions must be single-spaced and appear \protect\textit{below} the figure.  Captions can be as long as you want, but if they are longer than 4 lines in the list of figures, you must provide a short figure caption.\index{SanDiego}} 
+  \caption[A picture of San Diego. Short figure caption must be \protect{$< 4$} lines in the list of figures]
+{A picture of San Diego.  Short figure caption must be \protect{$< 4$} lines in the list of figures and match the start of the main figure caption verbatim. Note that figures must be on their own line (no neighboring text) and captions must be single-spaced and appear \protect\textit{below} the figure.  Captions can be as long as you want, but if they are longer than 4 lines in the list of figures, you must provide a short figure caption.\index{SanDiego}}
   \label{fig:sandiego}
 \end{figure}
 
@@ -249,7 +250,7 @@ While in Section \ref{ssec:figure_example} Figure \ref{fig:sandiego} we had a ma
 %%%% TABLE 1 %%%%
 \vspace{0.25in}
 \begin{table}[!ht]
-\caption[Short figure caption (must be \protect{$< 4$} lines in the list of tables)]{A table of when I get hungry.  Note that tables must be on their own line (no neighboring text) and captions must be single-spaced and appear \protect\textit{above} the table.  Captions can be as long as you want, but if they are longer than 4 lines in the list of figures, you must provide a short figure caption.}
+\caption[A table of when I get hungry.  Short table caption must be \protect{$< 4$} lines in the list of tables]{A table of when I get hungry. Short table caption must be \protect{$< 4$} lines in the list of tables and match the start of the main table caption verbatim.  Note that tables must be on their own line (no neighboring text) and captions must be single-spaced and appear \protect\textit{above} the table.  Captions can be as long as you want, but if they are longer than 4 lines in the list of figures, you must provide a short figure caption.}
 
 \vspace{-0.25in}
 \begin{center}


### PR DESCRIPTION
Grad Division has a rule that short figure/table captions must be a direct truncation of the long figure caption, which was not previously made clear by the template.  Proposed update makes this more directly clear.