### PR TITLE
fixed location of page numbers to all be bottom center

### DIFF
--- a/ucsd.cls
+++ b/ucsd.cls
@@ -1574,10 +1574,11 @@ on microfilm and electronically: }}\\
 
 % Definition of 'thesis' page style.
 %
-\def\ps@thesis{\let\@mkboth\markboth
-\def\@oddfoot{}\def\@evenfoot{}				% no feet
-\def\@oddhead{\hbox{}\hfil\rmfamily\thepage}		% heading (right)
-\def\@evenhead{\rmfamily\thepage\hfil\hbox{}}}		% heading (left)
+\def\ps@plain{\let\@mkboth\markboth%
+\def\@oddfoot{\hbox{}\hfil\rmfamily\thepage\hfil\hbox{}}% Pgno bot center
+\def\@evenfoot{\hbox{}\hfil\rmfamily\thepage\hfil\hbox{}}%
+\def\@oddhead{}% heading (right)
+\def\@evenhead{}% heading (left)
 %\pagenumbering{arabic}}					% (WBB)
 
 % Definition of 'preliminary' page style.


### PR DESCRIPTION
fall 2017 UCSD thesis requires that all page numbers be bottom center, not just the first page of each chapter. i updated the 'thesis' style page to be like the first page of a chapter. This seemed to fix this formatting issue for me.