### PR TITLE
added code to make both left and right margins just 1in

### DIFF
--- a/ucsd.cls
+++ b/ucsd.cls
@@ -1563,6 +1563,8 @@ on microfilm and electronically: }}\\
  \def\subsectionmark##1{}}
 
 % Definition of 'plain' page style.
+\addtolength{\oddsidemargin}{-.55in} %makes left and right margin 1"
+\addtolength{\textwidth}{.55in} %makes left and right margin 1"
 %
 \def\ps@plain{\let\@mkboth\markboth%
 \def\@oddfoot{\hbox{}\hfil\rmfamily\thepage\hfil\hbox{}}% Pgno bot center


### PR DESCRIPTION
New guidelines are that margins are 1". i added 2 lines of code to adjust the left and right margins to 1". This seemed to work if the code was outside the definition of the plain/thesis pages. i didn't mess with the top margin (should already be 1") or the bottom margin because the page number location was already nicely set to .5" from the bottom, and because these don't affect figure or figure facing formatting due to being on even/odd pages.