### PR TITLE
fix definition of "thesis" page style

### DIFF
--- a/ucsd.cls
+++ b/ucsd.cls
@@ -1576,11 +1576,11 @@ on microfilm and electronically: }}\\
 
 % Definition of 'thesis' page style.
 %
-\def\ps@plain{\let\@mkboth\markboth%
+\def\ps@thesis{\let\@mkboth\markboth%
 \def\@oddfoot{\hbox{}\hfil\rmfamily\thepage\hfil\hbox{}}% Pgno bot center
 \def\@evenfoot{\hbox{}\hfil\rmfamily\thepage\hfil\hbox{}}%
 \def\@oddhead{}% heading (right)
-\def\@evenhead{}% heading (left)
+\def\@evenhead{}}% heading (left)
 %\pagenumbering{arabic}}					% (WBB)
 
 % Definition of 'preliminary' page style.


### PR DESCRIPTION
In reference to https://github.com/ucsd-thesis/ucsd-thesis/issues/8, this commit allows Overleaf to compile ucsd-thesis.

I have not verified how this affects page layout, but this seems like a reasonable change since all it does is correct a missing bracket and correctly define a function name (that appears to have been misnamed from a copy/paste error)