### PR TITLE
Update template.tex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -304,10 +304,10 @@ What to do about things \cite{Martin_1983}.  What did he say \cite{Rilling_Insel
 %\setlength{\bibindent}{-\bibleftmargin}  % unindent the first line
 %\def\baselinestretch{1.0}  % force single spacing
 %\setlength{\bibitemsep}{0.16in}  % add extra space between items
+\singlespace  %to force bibilography environment to use single spacing for each entry 
+              %double spacing between entries remains
 \bibliography{template}  %% This looks for the bibliography in template.bib 
 %                          which should be formatted as a bibtex file.
 %                          and needs to be separately compiled into a bbl file.
-\singlespace  %to force bibilography environment to use single spacing for each entry 
-              %double spacing between entries remains
 \end{document}
 


### PR DESCRIPTION
I had to change \singlespace to be placed above the \bibliography command for bibliography entries to have single spacing with double spacing between entries. It would still use double spacing within bibliography items before I made this change.