### PR TITLE
Added singlelinecheck=false to make all captions justified

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -131,7 +131,9 @@
 \makeatother
 \usepackage{setspace}
 \doublespace
-\usepackage[font=small, width=0.9\textwidth]{caption}
+% singlelinecheck=false disables automatic centering for single-line captions,
+% so all the captions will be consistently justified
+\usepackage[font=small, width=0.9\textwidth, singlelinecheck=false]{caption}
 \usepackage[capposition=bottom]{floatrow} %force captions below figure per OGS requirement
 
 %% SUBFIG - Use this to place multiple images in a
@@ -310,4 +312,3 @@ What to do about things \cite{Martin_1983}.  What did he say \cite{Rilling_Insel
 \singlespace  %to force bibilography environment to use single spacing for each entry 
               %double spacing between entries remains
 \end{document}
-


### PR DESCRIPTION
Today a graduate division advisor brought up a formatting problem with my dissertation: I had one short caption that fit into one line and was centered, and other multi-line captions that were justified. I needed to make all the captions consistent one way or the other.

To fix this, I added an option that makes all the captions justified. This looks wrong with short captions, but it follows the rules.